### PR TITLE
Add vim-multiple-cursors to pathogen_plugins

### DIFF
--- a/pathogen_plugins.txt
+++ b/pathogen_plugins.txt
@@ -1,3 +1,4 @@
 ctrlp https://github.com/kien/ctrlp.vim.git
 vim-javascript https://github.com/pangloss/vim-javascript.git
 vim-commentary https://github.com/tpope/vim-commentary
+vim-multiple-cursors https://github.com/terryma/vim-multiple-cursors


### PR DESCRIPTION
I think this plugin is not being maintained and will get slow if you select too many things but I've been using it for a couple years and is useful every day :)

![example1](https://cloud.githubusercontent.com/assets/682943/11386580/ebd011ca-9365-11e5-884e-3b5c7b72e87b.gif)
